### PR TITLE
Add watchQuery and subscribe methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### vNEXT
 
 - Added support for **ApolloClient** `v0.5.0` ([PR #5](https://github.com/apollostack/angular1-apollo/pull/5))
+- Added `watchQuery` and `subscribe` methods thanks to `apollo-client-rxjs`
 
 ### v0.0.1
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
   },
   "homepage": "https://github.com/apollostack/angular1-apollo#readme",
   "peerDependencies": {
-    "apollo-client": "^0.3.0 || ^0.4.0 || ^0.5.0",
-    "angular": "^1.3.0"
+    "apollo-client": "^0.5.0",
+    "angular": "^1.3.0",
+    "rxjs": "^5.0.0-beta.12 || ^5.0.0-rc.1"
   },
   "devDependencies": {
     "@types/angular": "^1.5.13",
@@ -29,7 +30,11 @@
     "@types/node": "^6.0.38",
     "angular": "^1.5.8",
     "apollo-client": "^0.5.0",
+    "rxjs": "^5.0.0-rc.1",
     "typed-graphql": "1.0.2",
     "typescript": "2.0.6"
+  },
+  "dependencies": {
+    "apollo-client-rxjs": "~0.2.2"
   }
 }

--- a/src/ApolloQueryObservable.ts
+++ b/src/ApolloQueryObservable.ts
@@ -1,0 +1,3 @@
+import { RxObservableQuery } from 'apollo-client-rxjs';
+
+export class ApolloQueryObservable<T> extends RxObservableQuery<T> {}

--- a/src/apollo.provider.ts
+++ b/src/apollo.provider.ts
@@ -1,7 +1,13 @@
 import { ApolloQueryResult } from 'apollo-client';
+import { rxify } from 'apollo-client-rxjs';
+import { Observable } from 'rxjs/Observable';
 
 import ApolloClient from 'apollo-client';
 import * as angular from 'angular';
+
+import 'rxjs/add/observable/from';
+
+import { ApolloQueryObservable } from './ApolloQueryObservable';
 
 class Apollo {
   constructor(
@@ -13,12 +19,24 @@ class Apollo {
     this.check();
     
     return this.wrap(this.client.query(options));
+  }
+
+  public watchQuery(options: any): ApolloQueryObservable<ApolloQueryResult> {
+    return new ApolloQueryObservable(rxify(this.client.watchQuery)(options));
   } 
 
   public mutate(options: any): angular.IPromise<ApolloQueryResult> {
     this.check();
     
     return this.wrap(this.client.mutate(options));
+  }
+
+  public subscribe(options: any): Observable<any> {
+    if (typeof this.client.subscribe === 'undefined') {
+      throw new Error(`Your version of ApolloClient doesn't support subscriptions`);
+    }
+
+    return Observable.from(this.client.subscribe(options));
   }
 
   private check(): void {


### PR DESCRIPTION
Thanks to `apollo-client-rxjs`.

`Observable` could be used with [`observeOnScope`](https://github.com/wolfgangGoedel/observe-on-scope) operator.